### PR TITLE
Update BufferToUlong comment to reflect overflow checking

### DIFF
--- a/src/lib/mcciadklib_buffertoulong.c
+++ b/src/lib/mcciadklib_buffertoulong.c
@@ -151,7 +151,14 @@ Notes:
 	The input string must be UTF-8, latin1, ANSI, or a similar character
 	set that maps to ANSI.
 
-	There is no overflow checking.
+	Overflow of the magnitude (before negation) is detected: all
+	valid digits are consumed, ULONG_MAX is stored, and *pfOverflow
+	is set true.
+
+	Negation is done as unsigned arithmetic (0 - ulnum), which is
+	always exact in modular arithmetic.  No overflow is possible on
+	the negation path, because every value in [0, ULONG_MAX] maps
+	to a representable value in the same range.
 
 	It is odd to support negation for an unsigned number input.
 


### PR DESCRIPTION
## Summary
- Replace stale "There is no overflow checking" comment with accurate description of overflow detection on the magnitude path and negation behavior

## Test plan
- [ ] Doc-only change; CI compile tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)