### PR TITLE
Fix #33, #34: update library.properties version to 0.3.1-pre2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCCI Arduino Development Kit ADK
-version=0.3.0
+version=0.3.1-pre2
 author=Terry Moore, ChaeHee Won
 maintainer=MCCI Corporation <techsupport@mcci.com>
 sentence=The MCCI XDK ported to Arduino ("Arduino Development Kit").


### PR DESCRIPTION
## Summary
- Update `library.properties` version from 0.3.0 to 0.3.1-pre2, missed in the version bump commits for #34 and #33

## Test plan
- [ ] CI compile tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)